### PR TITLE
Improve jekyll sample code

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,9 @@ You can add this Rake task to validate a
 
 ~~~ ruby
 desc 'validate _site with validate website'
-task :validate => :build do
+task validate: :build do
   Dir.chdir('_site') do
-    system("validate-website-static --site '<CONFIG_URL>'")
-    exit($?.exitstatus)
+    sh("validate-website-static --site '<CONFIG_URL>'")
   end
 end
 ~~~


### PR DESCRIPTION
The `exit` call could be an unexpected chain halt. Here's an example:

```
task full_build: [:build, :validate, :release]
```

In this case, Users expect `rake full_build` could release after validate. But, it ends on validate by using `exit` in `validate` 