### PR TITLE
Support ruby 3

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -33,6 +33,10 @@ test:2.7:
   extends: .tests
   image: 'ruby:2.7'
 
+test:3.0:
+  extends: .tests
+  image: 'ruby:3.0'
+
 test:jruby:
   extends: .tests
   image: 'jruby:9.2.12-jre'

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ rvm:
   - 2.5
   - 2.6
   - 2.7
+  - 3.0
   - jruby-9.2.12.0
   - ruby-head
   - jruby-head

--- a/lib/validate_website/core.rb
+++ b/lib/validate_website/core.rb
@@ -118,7 +118,7 @@ module ValidateWebsite
     # @param [Hash] Validator options
     #
     def validate(doc, body, url, options)
-      validator = Validator.new(doc, body, options)
+      validator = Validator.new(doc, body, **options)
       if validator.valid?
         print color(:success, '.', options[:color]) # rspec style
       else

--- a/lib/validate_website/crawl.rb
+++ b/lib/validate_website/crawl.rb
@@ -46,7 +46,7 @@ module ValidateWebsite
 
       page.doc.search('//img[@src]').reduce(Set[]) do |result, elem|
         u = elem.attributes['src'].content
-        result << page.to_absolute(URI.parse(URI.encode(u)))
+        result << page.to_absolute(URI.parse(URI.encode_www_form_component(u)))
       end
     end
 

--- a/lib/validate_website/crawl.rb
+++ b/lib/validate_website/crawl.rb
@@ -46,7 +46,7 @@ module ValidateWebsite
 
       page.doc.search('//img[@src]').reduce(Set[]) do |result, elem|
         u = elem.attributes['src'].content
-        result << page.to_absolute(URI.parse(URI.encode_www_form_component(u)))
+        result << page.to_absolute(URI.parse(WEBrick::HTTPUtils.escape(u)))
       end
     end
 

--- a/lib/validate_website/static_link.rb
+++ b/lib/validate_website/static_link.rb
@@ -8,7 +8,7 @@ require 'spidr'
 # rubocop:disable Metrics/BlockLength
 StaticLink = Struct.new(:link, :site) do
   def link_uri
-    @link_uri = URI.parse(URI.encode(link))
+    @link_uri = URI.parse(URI.encode_www_form_component(link))
     @link_uri = URI.join(site, @link_uri) if @link_uri.host.nil?
     @link_uri
   end

--- a/lib/validate_website/static_link.rb
+++ b/lib/validate_website/static_link.rb
@@ -8,7 +8,7 @@ require 'spidr'
 # rubocop:disable Metrics/BlockLength
 StaticLink = Struct.new(:link, :site) do
   def link_uri
-    @link_uri = URI.parse(URI.encode_www_form_component(link))
+    @link_uri = URI.parse(WEBrick::HTTPUtils.escape(link))
     @link_uri = URI.join(site, @link_uri) if @link_uri.host.nil?
     @link_uri
   end

--- a/validate-website.gemspec
+++ b/validate-website.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'spidr', '~> 0.6'
   s.add_dependency 'tidy_ffi', '~> 1.0'
   s.add_dependency 'w3c_validators', '~> 1.3'
+  s.add_dependency 'webrick', '~> 1'
   s.add_development_dependency 'asciidoctor', '~> 1.5'
   s.add_development_dependency 'minitest', '~> 5.0'
   s.add_development_dependency 'rake', '~> 12'


### PR DESCRIPTION
ref:
- uri encoding: https://docs.knapsackpro.com/2020/uri-escape-is-obsolete-percent-encoding-your-query-string
- agument splat: https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/
- bundle webrick: https://www.ruby-lang.org/en/news/2020/12/25/ruby-3-0-0-released/