### PR TITLE
Fix test/static_test.rb with relative path

### DIFF
--- a/lib/validate_website/static.rb
+++ b/lib/validate_website/static.rb
@@ -61,8 +61,7 @@ module ValidateWebsite
     def check_page(file, page)
       if page.html? && options[:markup]
         keys = %i[ignore html5_validator]
-        # slice does not exists on Ruby <= 2.4
-        slice = Hash[[keys, options.values_at(*keys)].transpose]
+        slice = options.slice(*keys)
         validate(page.doc, page.body, file, slice)
       end
       check_static_not_found(page.links, page.url.to_s) if options[:not_found]

--- a/lib/validate_website/static.rb
+++ b/lib/validate_website/static.rb
@@ -65,13 +65,13 @@ module ValidateWebsite
         slice = Hash[[keys, options.values_at(*keys)].transpose]
         validate(page.doc, page.body, file, slice)
       end
-      check_static_not_found(page.links) if options[:not_found]
+      check_static_not_found(page.links, page.url.to_s) if options[:not_found]
     end
 
     # check files linked on static document
     # see lib/validate_website/runner.rb
-    def check_static_not_found(links)
-      static_links = links.map { |l| StaticLink.new(l, @site) }
+    def check_static_not_found(links, site = @site)
+      static_links = links.map { |l| StaticLink.new(l, site) }
       static_links.each do |static_link|
         next unless static_link.check?
 

--- a/test/data/news/index.html
+++ b/test/data/news/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<title>title</title>
+		<meta name="description" content="" />
+		<meta name="keywords" content="" />
+		<meta name="author" content="" />
+	</head>
+	<body>
+		<header>
+			<nav>
+				<ul>
+					<li><a href="ryzom-naissance-du-projet-libre-ryzom-forge.md" title="title">my url</a></li>
+				</ul>
+			</nav>
+		</header>
+	</body>
+</html>

--- a/test/static_test.rb
+++ b/test/static_test.rb
@@ -34,15 +34,14 @@ describe ValidateWebsite::Static do
   end
 
   it 'not found' do
-    pattern = File.join(File.dirname(__FILE__), '**/*.html')
     Dir.chdir('test/data') do
       _out, _err = capture_io do
-        @validate_website.crawl(pattern: pattern,
+        @validate_website.crawl(pattern: '**/*.html',
                                 site: 'https://linuxfr.org/',
                                 markup: false,
                                 not_found: true)
       end
-      _(@validate_website.not_founds_count).must_equal 213
+      _(@validate_website.not_founds_count).must_equal 210
     end
   end
 


### PR DESCRIPTION
Do not use full path in `not found test` since it does not reflect real usage on command line.